### PR TITLE
[Fix #3727] Add left option to enforced styles for Layout/AlignHash cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#6174](https://github.com/rubocop-hq/rubocop/pull/6174): Add `--display-only-fail-level-offenses` to only output offenses at or above the fail level. ([@robotdana][])
 * Add autocorrect to `Style/For`. ([@rrosenblum][])
 * [#6173](https://github.com/rubocop-hq/rubocop/pull/6173): Add `AllowImplicitReturn` option to `Rails/SaveBang` cop. ([@robotdana][])
+* [#3727](https://github.com/rubocop-hq/rubocop/issues/3727): Add `left` option to enforced styles for `Layout/AlignHash` cop. ([@albaer][])
 
 ### Bug fixes
 
@@ -3531,3 +3532,4 @@
 [@MagedMilad]: https://github.com/MagedMilad
 [@robotdana]: https://github.com/robotdana
 [@bacchir]: https://github.com/bacchir
+[@albaer]: https://github.com/albaer

--- a/lib/rubocop/cop/layout/align_hash.rb
+++ b/lib/rubocop/cop/layout/align_hash.rb
@@ -8,6 +8,7 @@ module RuboCop
       # options are:
       #
       #   - key (left align keys)
+      #   - left (left align keys, one space before hash rockets and values)
       #   - separator (align hash rockets and colons, right align keys)
       #   - table (left align keys, hash rockets, and values)
       #
@@ -24,6 +25,23 @@ module RuboCop
       #   {
       #     :foo => bar,
       #      :ba => baz
+      #   }
+      #
+      #   # good
+      #   {
+      #     :foo => bar,
+      #     :ba => baz
+      #   }
+      #
+      # @example EnforcedHashRocketStyle: left
+      #   # bad
+      #   {
+      #     :foo => bar,
+      #      :ba => baz
+      #   }
+      #   {
+      #     :foo => bar,
+      #     :ba  => baz
       #   }
       #
       #   # good
@@ -67,6 +85,22 @@ module RuboCop
       #   {
       #     foo: bar,
       #      ba: baz
+      #   }
+      #
+      #   # good
+      #   {
+      #     foo: bar,
+      #     ba: baz
+      #   }
+      # @example EnforcedColonStyle: left
+      #   # bad
+      #   {
+      #     foo: bar,
+      #      ba: baz
+      #   }
+      #   {
+      #     foo: bar,
+      #     ba:  baz
       #   }
       #
       #   # good
@@ -280,6 +314,7 @@ module RuboCop
         def new_alignment(key)
           case cop_config[key]
           when 'key'       then KeyAlignment.new
+          when 'left'      then LeftAlignment.new
           when 'table'     then TableAlignment.new
           when 'separator' then SeparatorAlignment.new
           else raise "Unknown #{key}: #{cop_config[key]}"

--- a/lib/rubocop/cop/mixin/hash_alignment.rb
+++ b/lib/rubocop/cop/mixin/hash_alignment.rb
@@ -23,6 +23,54 @@ module RuboCop
         end
       end
 
+      # Handles calculation of deltas when the enforced style is 'left'.
+      class LeftAlignment
+        def checkable_layout?(_node)
+          true
+        end
+
+        def deltas_for_first_pair(first_pair, _node)
+          {
+            separator: separator_delta(first_pair),
+            value: value_delta(first_pair)
+          }
+        end
+
+        def deltas(first_pair, current_pair)
+          if Util.begins_its_line?(current_pair.source_range)
+            key_delta = first_pair.key_delta(current_pair)
+            separator_delta = separator_delta(current_pair)
+            value_delta = value_delta(current_pair)
+
+            { key: key_delta, separator: separator_delta, value: value_delta }
+          else
+            {}
+          end
+        end
+
+        private
+
+        def separator_delta(pair)
+          if pair.hash_rocket?
+            correct_separator_column = pair.key.loc.expression.end.column + 1
+            actual_separator_column = pair.loc.operator.column
+
+            correct_separator_column - actual_separator_column
+          else
+            0
+          end
+        end
+
+        def value_delta(pair)
+          return 0 if pair.kwsplat_type?
+
+          correct_value_column = pair.loc.operator.end.column + 1
+          actual_value_column = pair.value.loc.column
+
+          correct_value_column - actual_value_column
+        end
+      end
+
       # Common functionality for checking alignment of hash values.
       module ValueAlignment
         def checkable_layout?(node)
@@ -54,8 +102,6 @@ module RuboCop
       class TableAlignment
         include ValueAlignment
 
-        # The table style is the only one where the first key-value pair can
-        # be considered to have bad alignment.
         def deltas_for_first_pair(first_pair, node)
           self.max_key_width = node.keys.map { |key| key.source.length }.max
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -95,6 +95,7 @@ literal are aligned according to configuration. The configuration
 options are:
 
   - key (left align keys)
+  - left (left align keys, one space before hash rockets and values)
   - separator (align hash rockets and colons, right align keys)
   - table (left align keys, hash rockets, and values)
 
@@ -115,6 +116,25 @@ can also be configured. The options are:
 {
   :foo => bar,
    :ba => baz
+}
+
+# good
+{
+  :foo => bar,
+  :ba => baz
+}
+```
+#### EnforcedHashRocketStyle: left
+
+```ruby
+# bad
+{
+  :foo => bar,
+   :ba => baz
+}
+{
+  :foo => bar,
+  :ba  => baz
 }
 
 # good
@@ -164,6 +184,25 @@ can also be configured. The options are:
 {
   foo: bar,
    ba: baz
+}
+
+# good
+{
+  foo: bar,
+  ba: baz
+}
+```
+#### EnforcedColonStyle: left
+
+```ruby
+# bad
+{
+  foo: bar,
+   ba: baz
+}
+{
+  foo: bar,
+  ba:  baz
 }
 
 # good


### PR DESCRIPTION
This PR address #3727.

The `key` option for hash alignment enforces that the keys are left-aligned, but does not look at any of the whitespace in the hash. So all of these are accepted:
```ruby
h1 = { a: 1,
       bbb: 2 }
h2 = { a:     1,
       bbb: 2 }
h3 = { a      =>1,
       b =>    2 }
```
It would be nice have a more strict option, especially so that autocorrect is able to clean up spacing issues in hashes. Since `key` is the default option and there are [explicit tests checking that it doesn't check separator or value placement](https://github.com/albaer/rubocop/blob/hash_align_left/spec/rubocop/cop/layout/align_hash_spec.rb#L220), I added a `left` option instead of modifying `key`. It enforces everything that `key` does, but also checks (and corrects) whitespace issues. It expects keys to be left-aligned and single spaces around hash rockets and the values. So the example above would be corrected to:
```ruby
h1 = { a: 1,
       bbb: 2 }
h2 = { a: 1,
       bbb: 2 }
h3 = { a => 1,
       b => 2 }
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
